### PR TITLE
varied input statement based on python version

### DIFF
--- a/Spiro1.py
+++ b/Spiro1.py
@@ -1,5 +1,6 @@
 import turtle
 import random
+import sys
 
 t = turtle.Turtle()
 
@@ -14,4 +15,7 @@ for j in range(i):
     t.forward(200)
     t.right(170)
     
-input("Press Enter to continue...")
+if sys.version_info[0] >= 3:
+    input("Press Enter to continue...")
+else:
+    raw_input("Press Enter to continue...")

--- a/crazyCatsCradle.py
+++ b/crazyCatsCradle.py
@@ -1,5 +1,6 @@
 import turtle
 import random
+import sys
 
 t = turtle.Turtle()
 
@@ -12,4 +13,7 @@ for j in range(i):
     t.forward(j*2)
     t.right(j)
 
-input("Press Enter to continue...")
+if sys.version_info[0] >= 3:
+    input("Press Enter to continue...")
+else:
+    raw_input("Press Enter to continue...")

--- a/octagonalDepths.py
+++ b/octagonalDepths.py
@@ -1,4 +1,5 @@
 import turtle
+import sys
 
 t = turtle.Turtle()
 s = turtle.Screen()
@@ -11,4 +12,7 @@ for x in range(i):
     t.forward(x)
     t.right(45)
 
-input("Press Enter to continue...")
+if sys.version_info[0] >= 3:
+    input("Press Enter to continue...")
+else:
+    raw_input("Press Enter to continue...")

--- a/randomDots.py
+++ b/randomDots.py
@@ -1,5 +1,6 @@
 import turtle
 import random
+import sys
 
 t = turtle.Turtle()
 s = turtle.Screen()
@@ -23,4 +24,7 @@ for i in range(numDots):
         t.goto(x, y)
     t.pendown()    
 
-input("Press Enter to continue...")
+if sys.version_info[0] >= 3:
+    input("Press Enter to continue...")
+else:
+    raw_input("Press Enter to continue...")

--- a/squarePyramid.py
+++ b/squarePyramid.py
@@ -1,4 +1,5 @@
 import turtle
+import sys
 
 t = turtle.Turtle()
 
@@ -7,4 +8,7 @@ for x in range(i):
     t.forward(x)
     t.right(90)
     
-input("Press Enter to continue...")
+if sys.version_info[0] >= 3:
+    input("Press Enter to continue...")
+else:
+    raw_input("Press Enter to continue...")

--- a/stars.py
+++ b/stars.py
@@ -63,4 +63,7 @@ for i in range(numDots):
     j = random.randint(0, 99)
     t.pencolor(colorList[j])
 
-input("Press Enter to continue...")
+if sys.version_info[0] >= 3:
+    input("Press Enter to continue...")
+else:
+    raw_input("Press Enter to continue...")


### PR DESCRIPTION
input in python2 causes an ugly (and not really accurate) error. raw_input gets around this error BUT does not exist in python3
so, we determine the python version and use the appropriate statement